### PR TITLE
fix: Update vmlinuz and initrd symlinks

### DIFF
--- a/inst-hooks/103-create-vmlinuz-symlink.postinst.sh
+++ b/inst-hooks/103-create-vmlinuz-symlink.postinst.sh
@@ -2,8 +2,8 @@
 
 # This postinst creates the missing vmlinuz and initrd.img symlinks
 
-ln -sf /boot/vmlinuz-4.9.110 /vmlinuz
-ln -sf /boot/vmlinuz-4.9.110 /vmlinuz.old
-ln -sf /boot/initrd.img-4.9.110 /initrd.img
-ln -sf /boot/initrd.img-4.9.110 /initrd.img.old
+ln -sf /boot/vmlinuz-4.9.110-opx /vmlinuz
+ln -sf /boot/vmlinuz-4.9.110-opx /vmlinuz.old
+ln -sf /boot/initrd.img-4.9.110-opx /initrd.img
+ln -sf /boot/initrd.img-4.9.110-opx /initrd.img.old
 


### PR DESCRIPTION
Update the postinst script that creates vmlinuz and initrd symlinks
so it points to the correct kernel image (4.9.110-opx).

Signed-off-by: Garrick He <garrick_he@dell.com>