### PR TITLE
fix: Remove unneeded postinst hook

### DIFF
--- a/inst-hooks/103-create-vmlinuz-symlink.postinst.sh
+++ b/inst-hooks/103-create-vmlinuz-symlink.postinst.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# This postinst creates the missing vmlinuz and initrd.img symlinks
-
-ln -sf /boot/vmlinuz-4.9.110-opx /vmlinuz
-ln -sf /boot/vmlinuz-4.9.110-opx /vmlinuz.old
-ln -sf /boot/initrd.img-4.9.110-opx /initrd.img
-ln -sf /boot/initrd.img-4.9.110-opx /initrd.img.old
-

--- a/release_bp/OPX_dell_base_stretch.xml
+++ b/release_bp/OPX_dell_base_stretch.xml
@@ -85,7 +85,6 @@ blueprint files.
   <inst_hook>99-set-corefile-setting.postinst.sh</inst_hook>
   <inst_hook>100-enable-ztd-mode.postinst.sh</inst_hook>
   <inst_hook>101-setup-ztd-dhclient.postinst.sh</inst_hook>
-  <inst_hook>103-create-vmlinuz-symlink.postinst.sh</inst_hook>
 
   <!-- Upgrade hooks -->
   <inst_hook>00-setup-opx-upgrade.pre-upgrade.sh</inst_hook>

--- a/release_bp/OPX_dell_kernel_only.xml
+++ b/release_bp/OPX_dell_kernel_only.xml
@@ -24,6 +24,5 @@
   <!-- Installer hooks -->
   <inst_hook>98-set-apt-sources.postinst.sh</inst_hook>
   <inst_hook>99-set-corefile-setting.postinst.sh</inst_hook>
-  <inst_hook>103-create-vmlinuz-symlink.postinst.sh</inst_hook>
 
 </blueprint>

--- a/release_bp/OPX_dell_kernel_only_stretch.xml
+++ b/release_bp/OPX_dell_kernel_only_stretch.xml
@@ -25,6 +25,5 @@
   <inst_hook>01-mod-rootdir-permission.preinst.sh</inst_hook>
   <inst_hook>98-set-apt-sources.stretch.postinst.sh</inst_hook>
   <inst_hook>99-set-corefile-setting.postinst.sh</inst_hook>
-  <inst_hook>103-create-vmlinuz-symlink.postinst.sh</inst_hook>
 
 </blueprint>


### PR DESCRIPTION
Remove the postinst hook that updates vmlinuz and initrd symlinks.

Signed-off-by: Garrick He <garrick_he@dell.com>